### PR TITLE
Fix: On Android TV, when you press delete one character, all are deleted

### DIFF
--- a/MaskedEditText/src/main/java/com/vicmikhailau/maskededittext/MaskedWatcher.kt
+++ b/MaskedEditText/src/main/java/com/vicmikhailau/maskededittext/MaskedWatcher.kt
@@ -16,6 +16,8 @@ open class MaskedWatcher(maskedFormatter: MaskedFormatter, editText: EditText) :
     // Fields
     // ===========================================================
 
+    private var beforeSymbolsCount = 0
+
     private val mMaskFormatter: MaskedFormatter = maskedFormatter
     private val mEditText: WeakReference<EditText> = WeakReference(editText)
     private var oldFormattedValue = ""
@@ -51,6 +53,15 @@ open class MaskedWatcher(maskedFormatter: MaskedFormatter, editText: EditText) :
 
     private fun setFormattedText(formattedString: IFormattedString) {
         val editText = mEditText.get() ?: return
+
+        val count = editText.text.count()
+
+        if (beforeSymbolsCount > count) {
+            beforeSymbolsCount = count
+            return
+        }
+
+        beforeSymbolsCount = count
 
         val deltaLength = formattedString.length - oldFormattedValue.length
 


### PR DESCRIPTION
#34

Tested on TV and phones
 